### PR TITLE
Controller-specific README and package-wide table

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@
 [![CI Status](https://github.com/orbcollective/mpc-examples/workflows/CI/badge.svg)](https://github.com/orbcollective/mpc-examples/actions)
 [![License](https://img.shields.io/badge/License-GPLv3-green.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
-This repository contains simplified examples of possible functionality in a Managed Pool Controller 
+This repository contains simplified examples of possible functionality in a Managed Pool Controller. These controllers are provided as examples for informational purposes only and have not been audited.
+
+# Controllers
+| Number | Controller      | Description |
+| ----------- | ----------- | ----------- |
+| 00 | [NullController](.pkg/mpc-examples/contracts/00-null-controller/README.md) | Empty controller that does nothing |
 
 ## Build and Test
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains simplified examples of possible functionality in a Mana
 # Controllers
 | Number | Controller      | Description |
 | ----------- | ----------- | ----------- |
-| 00 | [NullController](.pkg/mpc-examples/contracts/00-null-controller/README.md) | Empty controller that does nothing |
+| 00 | [NullController](./pkg/mpc-examples/contracts/00-null-controller/README.md) | Empty controller that does nothing |
 
 ## Build and Test
 

--- a/pkg/mpc-examples/contracts/00-null-controller/README.md
+++ b/pkg/mpc-examples/contracts/00-null-controller/README.md
@@ -3,10 +3,13 @@
 ## Summary
 NullController is a Managed Pool Controller that has no ability to issue commands to the Managed Pool. The NullController exists to be a bare minimum framework on top of which other controllers can be built. NullControllerFactory demonstrates a factory that can deploy both a Managed Pool and a controller that are both aware of each other without using a separate `initialize()` function.
 
+## Details
+If the NullController did anything interesting, this is where an explanation of what it can do and how it does it would be found. Since the NullController does nothing, the Managed Pool effectively becomes a Weighted Pool.
+
 ## Access Control
 ### NullController
 The controller itself does not implement any access control because it can take no actions. Other controllers may want to guard functions. Some potential access control paradigms include but are not limited to:
-- Public execution
+- Public execution (no access control)
 - Direct manager control
 - Timelocked manager control
 - Timelocked manager control and a guardian with the ability to veto
@@ -15,7 +18,7 @@ The controller itself does not implement any access control because it can take 
 The factory has one permissioned function: `disable()`. Using OZ's Ownable, the factory restricts permission only the contract `owner`. Ownable was chosen as it is a very simple concept that requires little explanation; however, it may be desirable to grant this permission to more than a single `owner`. Using a solution such as Balancer's [SingletonAuthentication](https://github.com/balancer/balancer-v2-monorepo/blob/3e99500640449585e8da20d50687376bcf70462f/pkg/solidity-utils/contracts/helpers/SingletonAuthentication.sol) could be a useful system for many controller factories.
 
 ## Managed Pool Functions
-The following list is a list of permissioned functions in a Managed Pool that a controller could potentially call. Only the checked boxes are functions that _this_ controller is able to call:
+The following list is a list of permissioned functions in a Managed Pool that a controller could potentially call. The NullController can call the functions below that are denoted with a checked box:
 
 - Gradual Updates
 	- [ ] `pool.updateSwapFeeGradually(...)`

--- a/pkg/mpc-examples/contracts/00-null-controller/README.md
+++ b/pkg/mpc-examples/contracts/00-null-controller/README.md
@@ -15,7 +15,7 @@ The controller itself does not implement any access control because it can take 
 - Timelocked manager control and a guardian with the ability to veto
 
 ### NullControllerFactory
-The factory has one permissioned function: `disable()`. Using OZ's Ownable, the factory restricts permission only the contract `owner`. Ownable was chosen as it is a very simple concept that requires little explanation; however, it may be desirable to grant this permission to more than a single `owner`. Using a solution such as Balancer's [SingletonAuthentication](https://github.com/balancer/balancer-v2-monorepo/blob/3e99500640449585e8da20d50687376bcf70462f/pkg/solidity-utils/contracts/helpers/SingletonAuthentication.sol) could be a useful system for many controller factories.
+The factory has one permissioned function: `disable()`. Using OZ's Ownable, the factory restricts permission to only the contract `owner`. Ownable was chosen as it is a very simple concept that requires little explanation; however, it may be desirable to grant this permission to more than a single `owner`. Using a solution such as Balancer's [SingletonAuthentication](https://github.com/balancer/balancer-v2-monorepo/blob/3e99500640449585e8da20d50687376bcf70462f/pkg/solidity-utils/contracts/helpers/SingletonAuthentication.sol) could be a useful system for many controller factories.
 
 ## Managed Pool Functions
 The following list is a list of permissioned functions in a Managed Pool that a controller could potentially call. The NullController can call the functions below that are denoted with a checked box:

--- a/pkg/mpc-examples/contracts/00-null-controller/README.md
+++ b/pkg/mpc-examples/contracts/00-null-controller/README.md
@@ -8,7 +8,7 @@ NullController is a Managed Pool Controller that has no ability to issue command
 The following list is a list of permissioned functions in a Managed Pool that a controller could potentially call. Only the checked boxes are functions that _this_ controller is able to call:
 
 - Gradual Updates
-	- [x] `pool.updateSwapFeeGradually(...)`
+	- [ ] `pool.updateSwapFeeGradually(...)`
 	- [ ] `pool.updateWeightsGradually(...)`
 - Enable/Disable Interactions
 	- [ ] `pool.setSwapEnabled(...)`

--- a/pkg/mpc-examples/contracts/00-null-controller/README.md
+++ b/pkg/mpc-examples/contracts/00-null-controller/README.md
@@ -1,0 +1,26 @@
+# NullController
+
+## Summary
+NullController is a Managed Pool Controller that has no ability to issue commands to the Managed Pool. The NullController exists to be a bare minimum framework on top of which other controllers can be built. NullControllerFactory demonstrates a factory that can deploy both a Managed Pool and a controller that are both aware of each other without using a separate `initialize()` function.
+
+## Managed Pool Functions
+
+The following list is a list of permissioned functions in a Managed Pool that a controller could potentially call. Only the checked boxes are functions that _this_ controller is able to call:
+
+- Gradual Updates
+	- [x] `pool.updateSwapFeeGradually(...)`
+	- [ ] `pool.updateWeightsGradually(...)`
+- Enable/Disable Interactions
+	- [ ] `pool.setSwapEnabled(...)`
+	- [ ] `pool.setJoinExitEnabled(...)`
+- LP Allowlist Management
+	- [ ] `pool.setMustAllowlistLPs(...)`
+	- [ ] `pool.addAllowedAddress(...)`
+	- [ ] `pool.removeAllowedAddress(...)`
+- Add/Remove Token
+	- [ ] `pool.addToken(...)`
+	- [ ] `pool.removeToken(...)`
+- Circuit Breaker Management
+	- [ ] `pool.setCircuitBreakers(...)`
+- Management Fee
+	- [ ] `pool.setManagementAumFeePercentage(...)`

--- a/pkg/mpc-examples/contracts/00-null-controller/README.md
+++ b/pkg/mpc-examples/contracts/00-null-controller/README.md
@@ -3,8 +3,18 @@
 ## Summary
 NullController is a Managed Pool Controller that has no ability to issue commands to the Managed Pool. The NullController exists to be a bare minimum framework on top of which other controllers can be built. NullControllerFactory demonstrates a factory that can deploy both a Managed Pool and a controller that are both aware of each other without using a separate `initialize()` function.
 
-## Managed Pool Functions
+## Access Control
+### NullController
+The controller itself does not implement any access control because it can take no actions. Other controllers may want to guard functions. Some potential access control paradigms include but are not limited to:
+- Public execution
+- Direct manager control
+- Timelocked manager control
+- Timelocked manager control and a guardian with the ability to veto
 
+### NullControllerFactory
+The factory has one permissioned function: `disable()`. Using OZ's Ownable, the factory restricts permission only the contract `owner`. Ownable was chosen as it is a very simple concept that requires little explanation; however, it may be desirable to grant this permission to more than a single `owner`. Using a solution such as Balancer's [SingletonAuthentication](https://github.com/balancer/balancer-v2-monorepo/blob/3e99500640449585e8da20d50687376bcf70462f/pkg/solidity-utils/contracts/helpers/SingletonAuthentication.sol) could be a useful system for many controller factories.
+
+## Managed Pool Functions
 The following list is a list of permissioned functions in a Managed Pool that a controller could potentially call. Only the checked boxes are functions that _this_ controller is able to call:
 
 - Gradual Updates


### PR DESCRIPTION
Top level README now has a table listing, linking, and briefly explaining the different controller examples in this repo. Going forward, each controller should have its own README following the example in NullController.