### PR TITLE
Migrate factory to _ensureEnabled format

### DIFF
--- a/pkg/mpc-examples/contracts/00-null-controller/NullControllerFactory.sol
+++ b/pkg/mpc-examples/contracts/00-null-controller/NullControllerFactory.sol
@@ -34,7 +34,7 @@ contract NullControllerFactory is Ownable {
 
     address public immutable managedPoolFactory;
     IVault public immutable balancerVault;
-    bool public isDisabled;
+    bool private _disabled;
 
     uint256 private _nextControllerSalt;
     address private _lastCreatedPool;
@@ -72,8 +72,7 @@ contract NullControllerFactory is Ownable {
      * @dev Deploy a Managed Pool and a Controller.
      */
     function create(MinimalPoolParams memory minimalParams) external {
-        require(!isDisabled, "Controller factory disabled");
-        require(!IManagedPoolFactory(managedPoolFactory).isDisabled(), "Pool factory disabled");
+        _ensureEnabled();
 
         bytes32 controllerSalt = bytes32(_nextControllerSalt);
         _nextControllerSalt += 1;
@@ -128,7 +127,17 @@ contract NullControllerFactory is Ownable {
      * be implemented to allow for different needs.
      */
     function disable() external onlyOwner {
-        isDisabled = true;
+        _ensureEnabled();
+        _disabled = true;
         emit Disabled();
+    }
+
+    function isDisabled() public view returns (bool) {
+        return _disabled;
+    }
+
+    function _ensureEnabled() internal view {
+        require(!isDisabled(), "Controller factory disabled");
+        require(!IManagedPoolFactory(managedPoolFactory).isDisabled(), "Pool factory disabled");
     }
 }

--- a/pkg/mpc-examples/contracts/00-null-controller/NullControllerFactory.sol
+++ b/pkg/mpc-examples/contracts/00-null-controller/NullControllerFactory.sol
@@ -132,12 +132,25 @@ contract NullControllerFactory is Ownable {
         emit Disabled();
     }
 
-    function isDisabled() public view returns (bool) {
-        return _disabled;
+    /**
+     * @dev Query whether this controller factory is disabled.
+     */
+    function isDisabled() external view returns (bool) {
+        return _disabled || _isPoolFactoryDisabled();
     }
 
+    /**
+     * @dev Query whether the pool factory is disabled.
+     */
+    function _isPoolFactoryDisabled() internal view returns (bool) {
+        return IManagedPoolFactory(managedPoolFactory).isDisabled();
+    }
+
+    /**
+     * @dev Revert if the factory is disabled.
+     */
     function _ensureEnabled() internal view {
-        require(!isDisabled(), "Controller factory disabled");
-        require(!IManagedPoolFactory(managedPoolFactory).isDisabled(), "Pool factory disabled");
+        require(!_disabled, "Controller factory disabled");
+        require(!_isPoolFactoryDisabled(), "Pool factory disabled");
     }
 }

--- a/pkg/mpc-examples/contracts/00-null-controller/NullControllerFactory.sol
+++ b/pkg/mpc-examples/contracts/00-null-controller/NullControllerFactory.sol
@@ -72,8 +72,7 @@ contract NullControllerFactory is Ownable {
      * @dev Deploy a Managed Pool and a Controller.
      */
     function create(MinimalPoolParams calldata minimalParams) external {
-        require(!isDisabled, "Controller factory disabled");
-        require(!IManagedPoolFactory(managedPoolFactory).isDisabled(), "Pool factory disabled");
+        _ensureEnabled();
 
         bytes32 controllerSalt = bytes32(_nextControllerSalt);
         _nextControllerSalt += 1;


### PR DESCRIPTION
Following [design patterns from BaseControllerFactory](https://github.com/balancer/balancer-v2-monorepo/blob/3e99500640449585e8da20d50687376bcf70462f/pkg/pool-utils/contracts/factories/BasePoolFactory.sol#L63-L73) for checking if a factory has been disabled

