### PR TITLE
refactor: use calldata for MinimalPoolParams

### DIFF
--- a/pkg/mpc-examples/contracts/00-null-controller/NullControllerFactory.sol
+++ b/pkg/mpc-examples/contracts/00-null-controller/NullControllerFactory.sol
@@ -71,7 +71,7 @@ contract NullControllerFactory is Ownable {
     /**
      * @dev Deploy a Managed Pool and a Controller.
      */
-    function create(MinimalPoolParams memory minimalParams) external {
+    function create(MinimalPoolParams calldata minimalParams) external {
         require(!isDisabled, "Controller factory disabled");
         require(!IManagedPoolFactory(managedPoolFactory).isDisabled(), "Pool factory disabled");
 


### PR DESCRIPTION
I think we can use calldata as data location here. What do you think?